### PR TITLE
Remove and out of stock products, fix API remove argument format

### DIFF
--- a/Controller/Product/Index.php
+++ b/Controller/Product/Index.php
@@ -5,6 +5,7 @@ namespace Clerk\Clerk\Controller\Product;
 use Clerk\Clerk\Controller\AbstractAction;
 use Clerk\Clerk\Model\Config;
 use Magento\Catalog\Model\Product\Visibility;
+use Magento\CatalogInventory\Model\ResourceModel\Stock\StatusFactory;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
@@ -25,6 +26,11 @@ class Index extends AbstractAction
     protected $eventPrefix = 'clerk_product';
 
     /**
+     * @var StatusFactory
+     */
+    protected $stockStatusFactory;
+
+    /**
      * Popup controller constructor.
      *
      * @param Context $context
@@ -34,10 +40,12 @@ class Index extends AbstractAction
         Context $context,
         ScopeConfigInterface $scopeConfig,
         CollectionFactory $productCollectionFactory,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        StatusFactory $stockStatusFactory
     )
     {
         $this->collectionFactory = $productCollectionFactory;
+        $this->stockStatusFactory = $stockStatusFactory;
         $this->addFieldHandlers();
 
         parent::__construct($context, $scopeConfig, $logger);
@@ -151,7 +159,10 @@ class Index extends AbstractAction
 
         //Filter on is_saleable if defined
         if ($this->scopeConfig->getValue(Config::XML_PATH_PRODUCT_SYNCHRONIZATION_SALABLE_ONLY)) {
-            $collection->addFieldToFilter('is_saleable', true);
+            $collection->getSelect()->where(
+                'stock_status_index.stock_status = ?',
+                \Magento\CatalogInventory\Model\Stock\Status::STATUS_IN_STOCK
+            );
         }
 
         $visibility = $this->scopeConfig->getValue(Config::XML_PATH_PRODUCT_SYNCHRONIZATION_VISIBILITY);

--- a/Model/Api.php
+++ b/Model/Api.php
@@ -64,10 +64,15 @@ class Api
     public function removeProduct($productId)
     {
         $params = [
-            'products'     => $productId,
+            'products'     => [$productId],
         ];
 
-        $this->get('product/remove', $params);
+        // work around a problem that API fails with query like ?products[0]=123&products[1]=456
+        // make it like this: ?products[]=123&products[]=456
+        $query = http_build_query($params);
+        $query = preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', $query);
+
+        $this->get('product/remove?' . $query);
     }
 
     /**


### PR DESCRIPTION
Hi!

Our customer reported an issue that sold out products show in Clerk. After code review I found following issues:
- controller product/index is_salable filter is silently ignored
- when product goes out of stock (purchase), the code should not skip it and remove this product from Clerk
- even further, remove API call didn't work as it returning error like `Invalid syntax in argument: products`. Turned out, API format changed.
  * as described in [documentation|https://docs.clerk.io/reference] - ?products=123,456 -- doesn't work
  * as called by the module - ?products[0]=123&products[1]=456 -- doesn't work
  * the only value that is accepted - ?products[]=123&products[]=456

Please review :)