### PR TITLE
Fix resolving Product image path.

### DIFF
--- a/Controller/Product/Index.php
+++ b/Controller/Product/Index.php
@@ -79,7 +79,8 @@ class Index extends AbstractAction
         //Add image fieldhandler
         $this->addFieldHandler('image', function($item) {
             $store = $this->_objectManager->get('Magento\Store\Model\StoreManagerInterface')->getStore();
-            $imageUrl = $store->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA) . 'catalog/product' . $item->getImage();
+            $itemImage = $item->getImage() ?? $item->getSmallImage() ?? $item->getThumbnail();
+            $imageUrl = $store->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA) . 'catalog/product' . $itemImage;
 
            return $imageUrl;
         });


### PR DESCRIPTION
getImage() not always works on Product entity, sometimes there is no value there, but even though product can have some image attached.

Could you please include it to your repository once it stops us with using Clerk solution on our production. 