### PR TITLE
Reuse image handler in controller and backend, configurable image thumbnail

### DIFF
--- a/Controller/Product/Index.php
+++ b/Controller/Product/Index.php
@@ -4,6 +4,7 @@ namespace Clerk\Clerk\Controller\Product;
 
 use Clerk\Clerk\Controller\AbstractAction;
 use Clerk\Clerk\Model\Config;
+use Clerk\Clerk\Model\Handler\Image;
 use Magento\Catalog\Model\Product\Visibility;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Framework\App\Action\Context;
@@ -26,6 +27,11 @@ class Index extends AbstractAction
     protected $eventPrefix = 'clerk_product';
 
     /**
+     * @var Image
+     */
+    protected $imageHandler;
+
+    /**
      * Popup controller constructor.
      *
      * @param Context $context
@@ -35,10 +41,12 @@ class Index extends AbstractAction
         Context $context,
         ScopeConfigInterface $scopeConfig,
         CollectionFactory $productCollectionFactory,
+        Image $imageHandler,
         LoggerInterface $logger
     )
     {
         $this->collectionFactory = $productCollectionFactory;
+        $this->imageHandler = $imageHandler;
         $this->addFieldHandlers();
 
         parent::__construct($context, $scopeConfig, $logger);
@@ -78,11 +86,7 @@ class Index extends AbstractAction
 
         //Add image fieldhandler
         $this->addFieldHandler('image', function($item) {
-            $store = $this->_objectManager->get('Magento\Store\Model\StoreManagerInterface')->getStore();
-            $itemImage = $item->getImage() ?? $item->getSmallImage() ?? $item->getThumbnail();
-            $imageUrl = $store->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA) . 'catalog/product' . $itemImage;
-
-           return $imageUrl;
+            return $this->imageHandler->handle($item);
         });
 
         //Add url fieldhandler

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -19,6 +19,7 @@ class Config
     const XML_PATH_PRODUCT_SYNCHRONIZATION_SALABLE_ONLY = 'clerk/product_synchronization/saleable_only';
     const XML_PATH_PRODUCT_SYNCHRONIZATION_VISIBILITY = 'clerk/product_synchronization/visibility';
     const XML_PATH_PRODUCT_SYNCHRONIZATION_DISABLE_ORDER_SYNCHRONIZATION = 'clerk/product_synchronization/disable_order_synchronization';
+    const XML_PATH_PRODUCT_SYNCHRONIZATION_IMAGE_TYPE = 'clerk/product_synchronization/image_type';
 
     /**
      * Search configuration

--- a/Model/Config/Source/ImageType.php
+++ b/Model/Config/Source/ImageType.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Clerk\Clerk\Model\Config\Source;
+
+use Magento\Catalog\Helper\Image;
+use Magento\Framework\Option\ArrayInterface;
+use Magento\Framework\View\ConfigInterface;
+use Magento\Framework\View\Design\ThemeInterface;
+use Magento\Theme\Model\ResourceModel\Theme\Collection;
+use Magento\Theme\Model\ResourceModel\Theme\CollectionFactory;
+
+class ImageType implements ArrayInterface
+{
+    /**
+     * @var ConfigInterface
+     */
+    protected $viewConfig;
+
+    /**
+     * @var CollectionFactory
+     */
+    protected $themeCollectionFactory;
+
+    /**
+     * @param ConfigInterface $viewConfig
+     * @param CollectionFactory $themeCollectionFactory
+     */
+    public function __construct(
+        ConfigInterface $viewConfig,
+        CollectionFactory $themeCollectionFactory
+    ) {
+        $this->viewConfig = $viewConfig;
+        $this->themeCollectionFactory = $themeCollectionFactory;
+    }
+
+    /**
+     * Finds image types for each frontend theme
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        $types = [];
+
+        /** @var Collection $themes */
+        $themes = $this->themeCollectionFactory->create();
+        $themes->addAreaFilter('frontend');
+
+        $common = [];
+        /** @var ThemeInterface $theme */
+        foreach ($themes as $theme) {
+            $config = $this->viewConfig->getViewConfig([
+                'themeModel' => $theme,
+            ]);
+            $mediaEntities = $config->getMediaEntities('Magento_Catalog', Image::MEDIA_TYPE_CONFIG_NODE);
+            $types[$theme->getCode()] = array_keys($mediaEntities);
+
+            $common = $common ? array_intersect($common, $types[$theme->getCode()]) : $types[$theme->getCode()];
+        }
+
+        foreach ($types as $theme => $mediaEntities) {
+            $types[$theme] = array_diff($mediaEntities, $common);
+        }
+        // add common in beginning
+        $types = ['Common' => $common] + $types;
+
+        $result = ['' => __('Original image')];
+        foreach ($types as $theme => $mediaEntities) {
+            $result[$theme] = [
+                'label' => $theme,
+                'value' => [],
+            ];
+            foreach ($mediaEntities as $type) {
+                $result[$theme]['value'][] = [
+                    'label' => $type,
+                    'value' => $type,
+                ];
+            }
+        }
+
+        return $result;
+    }
+}

--- a/Model/Handler/Image.php
+++ b/Model/Handler/Image.php
@@ -52,7 +52,6 @@ class Image
         // get image thumbnail from settings
         $imageType = $this->scopeConfig->getValue(Config::XML_PATH_PRODUCT_SYNCHRONIZATION_IMAGE_TYPE);
         if ($imageType) {
-            // FIXME: correct theme when in admin observer
             /** @var \Magento\Catalog\Helper\Image $helper */
             $helper = $this->helperFactory->create()
                 ->init($item, $imageType);

--- a/Model/Handler/Image.php
+++ b/Model/Handler/Image.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Clerk\Clerk\Model\Handler;
+
+use Clerk\Clerk\Model\Config;
+use Magento\Catalog\Helper\ImageFactory;
+use Magento\Catalog\Model\Product;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\StoreManagerInterface;
+
+class Image
+{
+    /**
+     * @var ImageFactory
+     */
+    protected $helperFactory;
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    protected $storeManager;
+
+    /**
+     * @param ImageFactory $helperFactory
+     * @param ScopeConfigInterface $scopeConfig
+     * @param StoreManagerInterface $storeManager
+     */
+    public function __construct(
+        ImageFactory $helperFactory,
+        ScopeConfigInterface $scopeConfig,
+        StoreManagerInterface $storeManager
+    ) {
+        $this->helperFactory = $helperFactory;
+        $this->scopeConfig = $scopeConfig;
+        $this->storeManager = $storeManager;
+    }
+
+    /**
+     * Builds product image URL
+     *
+     * @param Product $item
+     * @return string
+     */
+    public function handle(Product $item)
+    {
+        $imageUrl = null;
+        // get image thumbnail from settings
+        $imageType = $this->scopeConfig->getValue(Config::XML_PATH_PRODUCT_SYNCHRONIZATION_IMAGE_TYPE);
+        if ($imageType) {
+            // FIXME: correct theme when in admin observer
+            /** @var \Magento\Catalog\Helper\Image $helper */
+            $helper = $this->helperFactory->create()
+                ->init($item, $imageType);
+            $imageUrl = $helper->getUrl();
+            if ($imageUrl == $helper->getDefaultPlaceholderUrl()) {
+                // allow to try other types
+                $imageUrl = null;
+            }
+        }
+
+        if (!$imageUrl) {
+            $store = $this->storeManager->getStore();
+            $itemImage = $item->getImage() ?? $item->getSmallImage() ?? $item->getThumbnail();
+            $imageUrl = $store->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA) . 'catalog/product' . $itemImage;
+        }
+
+        return $imageUrl;
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -45,6 +45,10 @@
                     <label>Disable order synchronization</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="image_type" translate="label" type="select" sortOrder="70" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Image Type</label>
+                    <source_model>Clerk\Clerk\Model\Config\Source\ImageType</source_model>
+                </field>
             </group>
             <group id="search" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Search Settings</label>


### PR DESCRIPTION
Hello :)

Our QA reported that some Clerk images have wrong size https://prnt.sc/ix17oc
It turned out that Clerk sends original images as is, and this should be improved.

Magento 2 changed image generation approach. Now to generate thumbnail we need to pass image id that is registered in theme view.xml, and it will decide which picture (base, small, thumbnail etc.) to take and its dimentions to format to. And so I added corresponding admin configuration. It is still possible to send original image (default behavior) - send image/small image/thumbnail as is.

Second thing that was covered here is that when product info is generated in backend on product save, current store is adminhtml and not front one, thus we need to start layout emulation in this case.

Lastly, I reused image handler among controller and observer. This is the first step towards sharing field handlers.

Please review and share your thoughs.