### PR TITLE
Should redirect to cart if checkout/cart/redirect_to_cart is enabled

### DIFF
--- a/Controller/Checkout/Cart/Add.php
+++ b/Controller/Checkout/Cart/Add.php
@@ -54,8 +54,7 @@ class Add extends BaseAdd
             if ($this->getRequest()->getActionName() == 'add' && !$this->getRequest()->getParam('in_cart')) {
                 $this->_checkoutSession->setContinueShoppingUrl($this->_redirect->getRefererUrl());
             }
-
-            return $this->_url->getUrl('checkout/cart/added/id/' . $productId);
+            return $this->_url->getUrl('checkout/cart');
         }
 
         return $defaultUrl;


### PR DESCRIPTION
As previously implemented the powerstep page will be displayed whether it is enabled or not. This leads to a blank 'added' page being showed to the user if powerstep has not been configured. This change will fix that as I assume that it is not the intended behaviour.