### PR TITLE
Set product realtime sync default fields

### DIFF
--- a/Observer/ProductSaveAfterObserver.php
+++ b/Observer/ProductSaveAfterObserver.php
@@ -134,6 +134,7 @@ class ProductSaveAfterObserver implements ObserverInterface
                     }
                 }
 
+                $this->productAdapter->setFields([]);
                 $productInfo = $this->productAdapter->getInfoForItem($product);
 
                 $this->api->addProduct($productInfo);


### PR DESCRIPTION
Hi!

Just tried latest 3.0.0, activated Synchronization > Use Real-time Updates: Yes and tried saving a product, but nothing happens.

Turns out, this is because when called from controller, setFields is called, but when called from observer, it's not and default fields are not initialized.

This is first tiny step in hope to continue improving product save in real time.

Please have a look :)