### PR TITLE
Fixed two bugs founds

### DIFF
--- a/Controller/Customer/Index.php
+++ b/Controller/Customer/Index.php
@@ -27,14 +27,26 @@ class Index extends AbstractAction
     protected $eventPrefix = 'clerk_customer';
 
     /**
-     * Customer controller constructor.
-     *
+     * Index constructor.
      * @param Context $context
+     * @param StoreManagerInterface $storeManager
      * @param ScopeConfigInterface $scopeConfig
+     * @param LoggerInterface $logger
+     * @param ModuleList $moduleList
+     * @param ClerkLogger $ClerkLogger
      * @param CollectionFactory $customerCollectionFactory
+     * @param CustomerMetadataInterface $customerMetadata
      */
-    public function __construct(Context $context, StoreManagerInterface $storeManager, ScopeConfigInterface $scopeConfig, CollectionFactory $customerCollectionFactory, LoggerInterface $logger,  ModuleList $moduleList, ClerkLogger $ClerkLogger)
-    {
+    public function __construct(
+        Context $context,
+        StoreManagerInterface $storeManager,
+        ScopeConfigInterface $scopeConfig,
+        LoggerInterface $logger,
+        ModuleList $moduleList,
+        ClerkLogger $ClerkLogger,
+        CollectionFactory $customerCollectionFactory,
+        CustomerMetadataInterface $customerMetadata
+    ) {
         $this->collectionFactory = $customerCollectionFactory;
         $this->clerk_logger = $ClerkLogger;
         $this->_customerMetadata = $customerMetadata;

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -21,11 +21,11 @@
                 <load_more_text>Load More Results</load_more_text>
                 <no_results_text>No products found</no_results_text>
             </search>
-            <live_search>
+            <livesearch>
                 <enabled>0</enabled>
                 <include_categories>1</include_categories>
                 <template>live-search</template>
-            </live_search>
+            </livesearch>
             <powerstep>
                 <enabled>0</enabled>
                 <type>1</type>


### PR DESCRIPTION
Fixed the name of the element livesearch in the config.xml file.
The class Controller/Customer/Index.php was generating an error because the variable $customerMetadata wasn't in the construct.