### PR TITLE
Fails gracefully if it's not possible to retrieve the product that was added

### DIFF
--- a/view/frontend/templates/powerstep_popup.phtml
+++ b/view/frontend/templates/powerstep_popup.phtml
@@ -1,8 +1,8 @@
 <?php
 /** @var \Clerk\Clerk\Block\PowerstepPopup $block */
-$categoryIds = $block->getProduct() ? $block->getProduct()->getCategoryIds() : [];
 ?>
-<?php if ($block->shouldShow()) : ?>
+<?php if ($block->shouldShow() && $block->getProduct()) : ?>
+$categoryIds = $block->getProduct()->getCategoryIds();
 <div id="clerk_powerstep" class="clerk-popup">
     <div class="clerk_powerstep_header">
         <h2><?php echo $block->getHeaderText(); ?></h2>


### PR DESCRIPTION
We've noticed that in heavy-traffic situations the call to $block->getProduct() sometimes returns null (or false). When this happens, the line that sets the data-products attribute throws a fatal error.
In such situations it would be preferable not to show the powerstep popup if that means avoiding a fatal error.
Perhaps the product check could be incorporated in the shouldShow() method itself.

I also moved the line that retrieves the category id list inside the if() since this makes it safe to remove the product check from that line.