### PR TITLE
Clerk product fields fixes

### DIFF
--- a/Model/Adapter/Product.php
+++ b/Model/Adapter/Product.php
@@ -171,6 +171,30 @@ class Product extends AbstractAdapter
 
         try {
 
+        	//Add id fieldhandler
+            $this->addFieldHandler('id', function ($item) {
+                try {
+                    /**
+                     * @var \Magento\Catalog\Model\Product $item
+                     */
+                    return intval($item->getId());
+                } catch (\Exception $e) {
+                    return 0;
+                }
+            });
+
+            //Add description fieldhandler
+            $this->addFieldHandler('description', function ($item) {
+                try {
+                    /**
+                     * @var \Magento\Catalog\Model\Product $item
+                     */
+                    return strip_tags($item->getDescription());
+                } catch (\Exception $e) {
+                    return '';
+                }
+            });
+
             //Add price fieldhandler
             $this->addFieldHandler('price', function ($item) {
                 try {
@@ -229,7 +253,7 @@ class Product extends AbstractAdapter
 
             //Add categories fieldhandler
             $this->addFieldHandler('categories', function ($item) {
-                return $item->getCategoryIds();
+                return array_map('intval', $item->getCategoryIds());
             });
 
             //Add age fieldhandler

--- a/Model/Api.php
+++ b/Model/Api.php
@@ -90,7 +90,7 @@ class Api
             /** @var \Magento\Framework\HTTP\ZendClient $httpClient */
             $httpClient = $this->httpClientFactory->create();
             $httpClient->setUri($this->baseurl . $endpoint);
-            $httpClient->setRawData(json_encode($params), 'application/json');
+            $httpClient->setRawData(json_encode($params, JSON_NUMERIC_CHECK), 'application/json');
 
             $result = $httpClient->request('POST');
 


### PR DESCRIPTION
The purpose of this PR is to handle some specific problems that occurred when saving products in the backend:

- sometimes Clerk does not recognize ID as an integer
- html_tags are stripped on product's description
- category's id casted to integer

Furthermore, when the module creates the JSON for the API call, many integer/float fields are sent as strings and [JSON_NUMERIC_CHECK](https://www.php.net/manual/en/json.constants.php) is used to fix that.