### PR TITLE
Fix search result layout changes to 1column when it's not supposed to

### DIFF
--- a/Observer/ControllerActionLayoutRenderBeforeObserver.php
+++ b/Observer/ControllerActionLayoutRenderBeforeObserver.php
@@ -67,6 +67,6 @@ class ControllerActionLayoutRenderBeforeObserver implements ObserverInterface
      */
     private function isFacetedSearchEnabled()
     {
-        return $this->scopeConfig->isSetFlag(Config::XML_PATH_FACETED_SEARCH_ENABLED);
+        return $this->scopeConfig->isSetFlag(Config::XML_PATH_FACETED_SEARCH_ENABLED, ScopeInterface::SCOPE_STORE);
     }
 }


### PR DESCRIPTION
The scope level of the isFacetedSearchEnabled version is global which makes no sense since all config fields have to be configured on store level. Whether the value is true or false, it will always return false and set the search result page to a 1column page (even when the faceted search functionality is enabled).