### PR TITLE
use default attribute manufacturer instead custom brand

### DIFF
--- a/Model/Adapter/Product.php
+++ b/Model/Adapter/Product.php
@@ -326,7 +326,7 @@ class Product extends AbstractAdapter
                 'image',
                 'url',
                 'categories',
-                'brand',
+                'manufacturer',
                 'sku',
                 'age',
                 'on_sale',


### PR DESCRIPTION
Hey!

On checking module code I see adding custom attribute brand - it's not exists and Magento uses manufacturer. ofc, it's possible to add in Configuration, but if Module supports out the box default attribute name  - it looks as right fix.

As reference,  It's added in CategorySetup.php script [here](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Catalog/Setup/CategorySetup.php#L539-L553)

Please review,
Thanks! 