### PR TITLE
Fixed v4.5.1 di:compile issue.

### DIFF
--- a/Model/Adapter/Product.php
+++ b/Model/Adapter/Product.php
@@ -248,7 +248,7 @@ class Product extends AbstractAdapter
 
                     //Fix for configurable products
                     if ($item->getTypeId() === Configurable::TYPE_CODE) {
-                        $price = $item->getPriceInfo()->getPrice('regular_price')->getAmount()->getValue());
+                        $price = $item->getPriceInfo()->getPrice('regular_price')->getAmount()->getValue();
                     }
 
                     //Fix for Grouped products


### PR DESCRIPTION
Afternoon,

On updating the plugin to the v4.5.1 I'm unable to  run setup:di:compile. I've tracked the issue down to an additional un-needed bracket.

Thanks.

Clive