### PR TITLE
New release

### DIFF
--- a/Block/Adminhtml/System/Config/Field/FacetTitles.php
+++ b/Block/Adminhtml/System/Config/Field/FacetTitles.php
@@ -42,7 +42,7 @@ class FacetTitles extends Field
     public function getConfiguredAttributes()
     {
         $attributes = $this->_scopeConfig->getValue(Config::XML_PATH_FACETED_SEARCH_ATTRIBUTES, ScopeInterface::SCOPE_STORE);
-        $configuredAttributes = explode(',', $attributes);
+        $configuredAttributes = is_string($attributes) ? explode(',', $attributes) : array();
 
         return $configuredAttributes;
     }

--- a/Block/Powerstep.php
+++ b/Block/Powerstep.php
@@ -57,6 +57,11 @@ class Powerstep extends AbstractProduct
             ->getUrl();
     }
 
+    public function getExcludeState()
+    {
+        return $this->_scopeConfig->getValue(Config::XML_PATH_POWERSTEP_FILTER_DUPLICATES, ScopeInterface::SCOPE_STORE);
+    }
+
     public function getTemplates()
     {
         $configTemplates = $this->_scopeConfig->getValue(Config::XML_PATH_POWERSTEP_TEMPLATES, ScopeInterface::SCOPE_STORE);

--- a/Block/PowerstepPopup.php
+++ b/Block/PowerstepPopup.php
@@ -126,7 +126,13 @@ class PowerstepPopup extends Template
      */
     public function shouldShow()
     {
-        return ($this->getRequest()->getParam('isAjax')) || ($this->checkoutSession->getClerkShowPowerstep(true));
+        $showPowerstep = ($this->getRequest()->getParam('isAjax')) || ($this->checkoutSession->getClerkShowPowerstep(true));
+
+        if($showPowerstep){
+            $this->checkoutSession->setClerkShowPowerstep(false);
+        }
+
+        return $showPowerstep;
     }
 
     /**
@@ -137,6 +143,11 @@ class PowerstepPopup extends Template
     public function isAjax()
     {
         return $this->getRequest()->getParam('isAjax');
+    }
+
+    public function getExcludeState()
+    {
+        return $this->_scopeConfig->getValue(Config::XML_PATH_POWERSTEP_FILTER_DUPLICATES, ScopeInterface::SCOPE_STORE);
     }
 
     /**

--- a/Block/Widget/Content.php
+++ b/Block/Widget/Content.php
@@ -98,6 +98,15 @@ class Content extends \Magento\Framework\View\Element\Template implements \Magen
      */
     public function getSpanAttributes()
     {
+
+        $filter_category = $this->_scopeConfig->getValue(Config::XML_PATH_CATEGORY_FILTER_DUPLICATES, ScopeInterface::SCOPE_STORE);
+        $filter_product = $this->_scopeConfig->getValue(Config::XML_PATH_PRODUCT_FILTER_DUPLICATES, ScopeInterface::SCOPE_STORE);
+        $filter_cart = $this->_scopeConfig->getValue(Config::XML_PATH_CART_FILTER_DUPLICATES, ScopeInterface::SCOPE_STORE);
+
+        static $product_contents = 0;
+        static $cart_contents = 0;
+        static $category_contents = 0;
+
         $output = '<span ';
         $spanAttributes = [
             'class' => 'clerk',
@@ -115,6 +124,20 @@ class Content extends \Magento\Framework\View\Element\Template implements \Magen
             if ($productId) {
                 $spanAttributes['data-products'] = json_encode([$productId]);
             }
+            if($filter_product){
+                $unique_class = "clerk_" . (string)$product_contents;
+                $spanAttributes['class'] = 'clerk ' . $unique_class;
+                if($product_contents > 0){
+                    $filter_string = '';
+                    for($i = 0; $i < $product_contents; $i++){
+                        if($i > 0){
+                            $filter_string .= ', ';
+                        }
+                        $filter_string .= '.clerk_'.strval($i);
+                    }
+                $spanAttributes['data-exclude-from'] = $filter_string;
+                }
+            }
         }
 
         if ($this->getCategoryId()) {
@@ -128,21 +151,77 @@ class Content extends \Magento\Framework\View\Element\Template implements \Magen
             if ($categoryId) {
                 $spanAttributes['data-category'] = $categoryId;
             }
+            if($filter_category){
+                $unique_class = "clerk_" . (string)$category_contents;
+                $spanAttributes['class'] = 'clerk ' . $unique_class;
+                if($category_contents > 0){
+                    $filter_string = '';
+                    for($i = 0; $i < $category_contents; $i++){
+                        if($i > 0){
+                            $filter_string .= ', ';
+                        }
+                        $filter_string .= '.clerk_'.strval($i);
+                    }
+                $spanAttributes['data-exclude-from'] = $filter_string;
+                }
+            }
         }
 
         if ($this->getType() === 'cart') {
             $spanAttributes['data-products'] = json_encode($this->getCartProducts());
             $spanAttributes['data-template'] = '@' . $this->getCartContents();
+            if($filter_cart){
+                $unique_class = "clerk_" . (string)$cart_contents;
+                $spanAttributes['class'] = 'clerk ' . $unique_class;
+                if($cart_contents > 0){
+                    $filter_string = '';
+                    for($i = 0; $i < $cart_contents; $i++){
+                        if($i > 0){
+                            $filter_string .= ', ';
+                        }
+                        $filter_string .= '.clerk_'.strval($i);
+                    }
+                $spanAttributes['data-exclude-from'] = $filter_string;
+                }
+            }
         }
 
         if ($this->getType() === 'category') {
             $spanAttributes['data-category'] = $this->getCurrentCategory();
             $spanAttributes['data-template'] = '@' . $this->getCategoryContents();
+            if($filter_category){
+                $unique_class = "clerk_" . (string)$category_contents;
+                $spanAttributes['class'] = 'clerk ' . $unique_class;
+                if($category_contents > 0){
+                    $filter_string = '';
+                    for($i = 0; $i < $category_contents; $i++){
+                        if($i > 0){
+                            $filter_string .= ', ';
+                        }
+                        $filter_string .= '.clerk_'.strval($i);
+                    }
+                $spanAttributes['data-exclude-from'] = $filter_string;
+                }
+            }
         }
 
         if ($this->getType() === 'product') {
             $spanAttributes['data-products'] = json_encode([$this->getCurrentProduct()]);
             $spanAttributes['data-template'] = '@' . $this->getProductContents();
+            if($filter_product){
+                $unique_class = "clerk_" . (string)$product_contents;
+                $spanAttributes['class'] = 'clerk ' . $unique_class;
+                if($product_contents > 0){
+                    $filter_string = '';
+                    for($i = 0; $i < $product_contents; $i++){
+                        if($i > 0){
+                            $filter_string .= ', ';
+                        }
+                        $filter_string .= '.clerk_'.strval($i);
+                    }
+                $spanAttributes['data-exclude-from'] = $filter_string;
+                }
+            }
         }
 
         foreach ($spanAttributes as $attribute => $value) {
@@ -150,6 +229,10 @@ class Content extends \Magento\Framework\View\Element\Template implements \Magen
         }
 
         $output .= '></span>';
+
+        $product_contents++;
+        $cart_contents++;
+        $category_contents++;
 
         return $output;
     }
@@ -225,6 +308,15 @@ class Content extends \Magento\Framework\View\Element\Template implements \Magen
 
     private function getHtmlForContent($content)
     {
+
+        $filter_category = $this->_scopeConfig->getValue(Config::XML_PATH_CATEGORY_FILTER_DUPLICATES, ScopeInterface::SCOPE_STORE);
+        $filter_product = $this->_scopeConfig->getValue(Config::XML_PATH_PRODUCT_FILTER_DUPLICATES, ScopeInterface::SCOPE_STORE);
+        $filter_cart = $this->_scopeConfig->getValue(Config::XML_PATH_CART_FILTER_DUPLICATES, ScopeInterface::SCOPE_STORE);
+
+        static $product_contents = 0;
+        static $cart_contents = 0;
+        static $category_contents = 0;
+
         $output = '<span ';
         $spanAttributes = [
             'class' => 'clerk',
@@ -242,6 +334,20 @@ class Content extends \Magento\Framework\View\Element\Template implements \Magen
             if ($productId) {
                 $spanAttributes['data-products'] = json_encode([$productId]);
             }
+            if($filter_product){
+                $unique_class = "clerk_" . (string)$product_contents;
+                $spanAttributes['class'] = 'clerk ' . $unique_class;
+                if($product_contents > 0){
+                    $filter_string = '';
+                    for($i = 0; $i < $product_contents; $i++){
+                        if($i > 0){
+                            $filter_string .= ', ';
+                        }
+                        $filter_string .= '.clerk_'.strval($i);
+                    }
+                $spanAttributes['data-exclude-from'] = $filter_string;
+                }
+            }
         }
 
         if ($this->getCategoryId()) {
@@ -255,18 +361,74 @@ class Content extends \Magento\Framework\View\Element\Template implements \Magen
             if ($categoryId) {
                 $spanAttributes['data-category'] = $categoryId;
             }
+            if($filter_category){
+                $unique_class = "clerk_" . (string)$category_contents;
+                $spanAttributes['class'] = 'clerk ' . $unique_class;
+                if($category_contents > 0){
+                    $filter_string = '';
+                    for($i = 0; $i < $category_contents; $i++){
+                        if($i > 0){
+                            $filter_string .= ', ';
+                        }
+                        $filter_string .= '.clerk_'.strval($i);
+                    }
+                $spanAttributes['data-exclude-from'] = $filter_string;
+                }
+            }
         }
 
         if ($this->getType() === 'cart') {
             $spanAttributes['data-products'] = json_encode($this->getCartProducts());
+            if($filter_cart){
+                $unique_class = "clerk_" . (string)$cart_contents;
+                $spanAttributes['class'] = 'clerk ' . $unique_class;
+                if($cart_contents > 0){
+                    $filter_string = '';
+                    for($i = 0; $i < $cart_contents; $i++){
+                        if($i > 0){
+                            $filter_string .= ', ';
+                        }
+                        $filter_string .= '.clerk_'.strval($i);
+                    }
+                $spanAttributes['data-exclude-from'] = $filter_string;
+                }
+            }
         }
 
         if ($this->getType() === 'category') {
             $spanAttributes['data-category'] = $this->getCurrentCategory();
+            if($filter_category){
+                $unique_class = "clerk_" . (string)$category_contents;
+                $spanAttributes['class'] = 'clerk ' . $unique_class;
+                if($category_contents > 0){
+                    $filter_string = '';
+                    for($i = 0; $i < $category_contents; $i++){
+                        if($i > 0){
+                            $filter_string .= ', ';
+                        }
+                        $filter_string .= '.clerk_'.strval($i);
+                    }
+                $spanAttributes['data-exclude-from'] = $filter_string;
+                }
+            }
         }
 
         if ($this->getType() === 'product') {
             $spanAttributes['data-products'] = json_encode([$this->getCurrentProduct()]);
+            if($filter_product){
+                $unique_class = "clerk_" . (string)$product_contents;
+                $spanAttributes['class'] = 'clerk ' . $unique_class;
+                if($product_contents > 0){
+                    $filter_string = '';
+                    for($i = 0; $i < $product_contents; $i++){
+                        if($i > 0){
+                            $filter_string .= ', ';
+                        }
+                        $filter_string .= '.clerk_'.strval($i);
+                    }
+                $spanAttributes['data-exclude-from'] = $filter_string;
+                }
+            }
         }
 
         foreach ($spanAttributes as $attribute => $value) {
@@ -274,6 +436,10 @@ class Content extends \Magento\Framework\View\Element\Template implements \Magen
         }
 
         $output .= "></span>\n";
+
+        $product_contents++;
+        $cart_contents++;
+        $category_contents++;
 
         return $output;
     }

--- a/Controller/AbstractAction.php
+++ b/Controller/AbstractAction.php
@@ -169,7 +169,7 @@ abstract class AbstractAction extends Action
             $scopeID = $this->verifyKeys($request);
             $request->setParams(['scope_id' => $scopeID]);
             $request->setParams(['scope' => 'store']);
-            
+
             if($this->verifyWebsiteKeys($request) !==0){
                 $scopeID = $this->verifyWebsiteKeys($request);
                 $request->setParams(['scope_id' => $scopeID]);
@@ -200,14 +200,14 @@ abstract class AbstractAction extends Action
 
             $privateKey = $request->getParam('private_key');
             $publicKey = $request->getParam('key');
-           
+
             $storeids = $this->getStores();
             foreach($storeids as $scopeID){
                 if ($privateKey == $this->getPrivateKey($scopeID) && $publicKey == $this->getPublicKey($scopeID)) {
                     return $scopeID;
                 }
             }
-           
+
             return 0;
 
         } catch (\Exception $e) {
@@ -230,14 +230,14 @@ abstract class AbstractAction extends Action
 
             $privateKey = $request->getParam('private_key');
             $publicKey = $request->getParam('key');
-            
+
             $websiteids = $this->getWebsites();
             foreach($websiteids as $scopeID){
                 if ($privateKey == $this->getPrivateWebsiteKey($scopeID) && $publicKey == $this->getPublicWebsiteKey($scopeID)) {
                     return $scopeID;
                 }
             }
-            
+
             return 0;
 
         } catch (\Exception $e) {

--- a/Controller/Category/Index.php
+++ b/Controller/Category/Index.php
@@ -80,7 +80,10 @@ class Index extends AbstractAction
         $this->pageHelper = $pageHelper;
         $this->storeManager = $storeManager;
         $this->clerk_logger = $ClerkLogger;
-
+        $this->fields = array(
+            "entity_id",
+            "parent_id"
+        );
         $this->addFieldHandlers();
 
         parent::__construct($context, $storeManager, $scopeConfig, $logger, $moduleList, $ClerkLogger);
@@ -137,6 +140,13 @@ class Index extends AbstractAction
                 foreach ($collection as $resourceItem) {
 
                     $item = [];
+
+                    $item['parent'] = $resourceItem->getParentId();
+                    $item['url'] = $resourceItem->getUrl();
+
+                    $children = $resourceItem->getAllChildren(true);
+                    $subcategories = array_values(array_diff($children, [$resourceItem->getId()]));
+                    $item['subcategories'] = $subcategories;
 
                     foreach ($this->fields as $field) {
 
@@ -202,9 +212,8 @@ class Index extends AbstractAction
             $collection->addPathsFilter('1/' . $rootCategory . '/%');
             $collection->addFieldToFilter('is_active',array("in"=>array('1')));
 
-            $collection->setPageSize($this->limit)
-                ->setCurPage($this->page)
-                ->addOrder($this->orderBy, $this->order);
+            $offset = ($this->page == 0) ? 0 : ($this->page * $this->limit);
+            $collection->setPage($offset, $this->limit)->addOrder($this->orderBy, $this->order);
 
             return $collection;
 

--- a/Controller/Customer/Index.php
+++ b/Controller/Customer/Index.php
@@ -38,7 +38,7 @@ class Index extends AbstractAction
         $this->clerk_logger = $ClerkLogger;
         $this->_customerMetadata = $customerMetadata;
         $this->_storeManager = $storeManager;
-    
+
         parent::__construct($context, $storeManager, $scopeConfig, $logger, $moduleList, $ClerkLogger);
     }
 
@@ -52,6 +52,7 @@ class Index extends AbstractAction
                 $this->getResponse()
                     ->setHttpResponseCode(200)
                     ->setHeader('Content-Type', 'application/json', true);
+
                 if (!empty($this->scopeConfig->getValue(Config::XML_PATH_CUSTOMER_SYNCHRONIZATION_EXTRA_ATTRIBUTES, $this->scope, $this->scopeid))) {
 
                     $Fields = explode(',',str_replace(' ','', $this->scopeConfig->getValue(Config::XML_PATH_CUSTOMER_SYNCHRONIZATION_EXTRA_ATTRIBUTES, $this->scope, $this->scopeid)));
@@ -68,27 +69,26 @@ class Index extends AbstractAction
 
                         $_customer = [];
                         $_customer['id'] = $customer['entity_id'];
-                        $_customer['name'] = $customer['firstname'] . " " . ($customer['middlename'] ? $customer['middlename'] . " " : "") . $customer['lastname'];
+                        $_customer['name'] = $customer['firstname'] . " " . (!is_null($customer['middlename']) ? $customer['middlename'] . " " : "") . $customer['lastname'];
                         $_customer['email'] = $customer['email'];
-    
+
                         foreach ($Fields as $Field) {
                             if (isset($customer[$Field])) {
                                 if ($Field == "gender") {
-    
+
                                     $_customer[$Field] = $this->getCustomerGender($customer[$Field]);
-    
+
                                 } else {
-    
+
                                     $_customer[$Field] = $customer[$Field];
-    
+
                                 }
-    
+
                             }
                         }
-    
-                        $Customers[] = $customer;
+
+                        $Customers[] = $_customer;
                     }
-                
 
                 if ($this->debug) {
                     $this->getResponse()->setBody(json_encode($Customers, JSON_PRETTY_PRINT));
@@ -112,7 +112,7 @@ class Index extends AbstractAction
         }
 
     }
-    
+
     public function getCustomerCollection($page, $limit, $storeid)
     {
         $store = $this->_storeManager->getStore($storeid);

--- a/Controller/Page/Index.php
+++ b/Controller/Page/Index.php
@@ -21,7 +21,6 @@ use Clerk\Clerk\Controller\Logger\ClerkLogger;
 class Index extends AbstractAction
 {
 
-    
     /**
      * @var ClerkLogger
      */
@@ -95,7 +94,8 @@ class Index extends AbstractAction
         try {
 
             $Include_pages = $this->scopeConfig->getValue(Config::XML_PATH_INCLUDE_PAGES, $this->scope, $this->scopeid);
-            $Pages_Additional_Fields = explode(',',$this->scopeConfig->getValue(Config::XML_PATH_PAGES_ADDITIONAL_FIELDS, $this->scope, $this->scopeid));
+
+            $Pages_Additional_Fields = is_string($this->scopeConfig->getValue(Config::XML_PATH_PAGES_ADDITIONAL_FIELDS, $this->scope, $this->scopeid)) ? explode(',',$this->scopeConfig->getValue(Config::XML_PATH_PAGES_ADDITIONAL_FIELDS, $this->scope, $this->scopeid)) : array();
 
             $pages = [];
 
@@ -121,7 +121,7 @@ class Index extends AbstractAction
                         $page['url'] = $url;
                         $page['title'] = $page_default['title'];
                         $page['text'] = $page_default['content'];
-                        
+
                         if (!$this->ValidatePage($page)) {
 
                             continue;
@@ -165,7 +165,7 @@ class Index extends AbstractAction
                         $page['url'] = $url;
                         $page['title'] = $page_store['title'];
                         $page['text'] = $page_store['content'];
-                       
+
                         if (!$this->ValidatePage($page)) {
 
                             continue;

--- a/Model/Adapter/AbstractAdapter.php
+++ b/Model/Adapter/AbstractAdapter.php
@@ -96,7 +96,7 @@ abstract class AbstractAdapter
     public function getResponse($fields, $page, $limit, $orderBy, $order, $scope, $scopeid)
     {
         try {
-            
+
             $this->setFields($fields, $scope, $scopeid);
 
             $collection = $this->prepareCollection($page, $limit, $orderBy, $order, $scope, $scopeid);
@@ -111,7 +111,7 @@ abstract class AbstractAdapter
                     $response[] = $item;
                 }
             }
-            
+
             return $response;
 
         } catch (\Exception $e) {
@@ -136,7 +136,7 @@ abstract class AbstractAdapter
     public function getInfoForItem($resourceItem,$scope, $scopeid)
     {
         try {
-            
+
             $info = [];
 
             $this->setFields([], $scope, $scopeid);
@@ -148,10 +148,10 @@ abstract class AbstractAdapter
 
                 //21-10-2021 KKY Additional Fields for Configurable and grouped Products - start
                 $additionalFields = $this->scopeConfig->getValue(Config::XML_PATH_PRODUCT_SYNCHRONIZATION_ADDITIONAL_FIELDS, $scope, $scopeid);
-                $customFields = str_replace(' ','' ,explode(',', $additionalFields));
+                $customFields = is_string($additionalFields) ? str_replace(' ','' ,explode(',', $additionalFields)) : array();
 
                 if(in_array($field, $customFields)){
-                    
+
                     if ($resourceItem->getTypeId() === Configurable::TYPE_CODE){
 
                         $configurablelist=[];
@@ -164,12 +164,12 @@ abstract class AbstractAdapter
                                 }elseif(isset($simple[$entityField])){
                                     $configurablelist[] = $this->getAttributeValue($simple, $entityField);
                                 }
-                            }   
+                            }
                         }
                         if(!empty($configurablelist)){
                             $info["child_".$this->getFieldName($field)."s"] = array_values(array_unique($configurablelist));
                         }
-                        
+
                     }
 
                     if ($resourceItem->getTypeId() === "grouped"){
@@ -180,7 +180,7 @@ abstract class AbstractAdapter
                         //find simple products
                         if (!empty($associatedProducts)) {
                             foreach ($associatedProducts as $associatedProduct) {
-                               
+
                                 if (isset($associatedProduct[$field])) {
                                     $groupedList[] = $this->getAttributeValue($associatedProduct, $field);
                                 }elseif(isset($associatedProduct[$entityField])){
@@ -188,7 +188,7 @@ abstract class AbstractAdapter
                                 }
                             }
                         }
-                        
+
                         if(!empty($groupedList)){
                             $info["child_".$this->getFieldName($field)."s"] = array_values(array_unique($groupedList));
                         }
@@ -196,11 +196,11 @@ abstract class AbstractAdapter
                     }
                 }
                 //21-10-2021 KKY Additional Fields for Configurable and grouped Products - end
-               
+
                 if (isset($this->fieldHandlers[$field])) {
                     if (in_array($this->getFieldName($field), ['price','list_price'])) {
                             $price = str_replace(',','',$this->fieldHandlers[$field]($resourceItem));
-                            $info[$this->getFieldName($field)] = (float)$price;           
+                            $info[$this->getFieldName($field)] = (float)$price;
                     }
                     else {
                         $info[$this->getFieldName($field)] = $this->fieldHandlers[$field]($resourceItem);
@@ -211,7 +211,7 @@ abstract class AbstractAdapter
                     $info[$this->getFieldName($field)] = "";
                 }
             }
-            
+
             return $info;
         } catch (\Exception $e) {
 
@@ -289,7 +289,7 @@ abstract class AbstractAdapter
     }
 
     /**
-     * Get default fields 
+     * Get default fields
      * @return array
      */
     abstract protected function getDefaultFields($scope, $scopeid);

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -12,7 +12,7 @@ class Config
     const XML_PATH_LANGUAGE = 'clerk/general/language';
     const XML_PATH_INCLUDE_PAGES = 'clerk/general/include_pages';
     const XML_PATH_PAGES_ADDITIONAL_FIELDS = 'clerk/general/pages_additional_fields';
-    
+
 
     /**
      * Product Synchronization configuration
@@ -73,6 +73,7 @@ class Config
     const XML_PATH_POWERSTEP_ENABLED = 'clerk/powerstep/enabled';
     const XML_PATH_POWERSTEP_TYPE = 'clerk/powerstep/type';
     const XML_PATH_POWERSTEP_TEMPLATES = 'clerk/powerstep/templates';
+    const XML_PATH_POWERSTEP_FILTER_DUPLICATES = 'clerk/powerstep/powerstep_filter';
 
     /**
      * Exit intent configuration
@@ -85,18 +86,21 @@ class Config
      */
     const XML_PATH_CATEGORY_ENABLED = 'clerk/category/enabled';
     const XML_PATH_CATEGORY_CONTENT = 'clerk/category/content';
+    const XML_PATH_CATEGORY_FILTER_DUPLICATES = 'clerk/category/category_filter';
 
     /**
      * Product configuration
      */
     const XML_PATH_PRODUCT_ENABLED = 'clerk/product/enabled';
     const XML_PATH_PRODUCT_CONTENT = 'clerk/product/content';
+    const XML_PATH_PRODUCT_FILTER_DUPLICATES = 'clerk/product/product_filter';
 
     /**
      * Cart configuration
      */
     const XML_PATH_CART_ENABLED = 'clerk/cart/enabled';
     const XML_PATH_CART_CONTENT = 'clerk/cart/content';
+    const XML_PATH_CART_FILTER_DUPLICATES = 'clerk/cart/cart_filter';
 
     /**
      * Logger configuration

--- a/Model/Config/Source/MultiselectFacetAttributes.php
+++ b/Model/Config/Source/MultiselectFacetAttributes.php
@@ -43,6 +43,12 @@ class MultiselectFacetAttributes implements ArrayInterface
     public function toArray()
     {
         $attributes = $this->getConfiguredAttributes();
+	
+	$attributes_defined = is_null($attributes) ? false : true;
+
+	if(!$attributes_defined){
+		return [];
+	}
 
         $values = [];
 
@@ -58,6 +64,7 @@ class MultiselectFacetAttributes implements ArrayInterface
      */
     private function getConfiguredAttributes()
     {
+	    setcookie('stubbe', ScopeInterface::SCOPE_STORE, 86400);
         return $this->scopeConfig->getValue(Config::XML_PATH_FACETED_SEARCH_ATTRIBUTES, ScopeInterface::SCOPE_STORE);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,19 @@
 {
   "name": "clerkio/magento2",
   "description": "",
-  "version": "4.5.3",
+  "version": "4.6.0",
   "authors": [
+    {
+      "name": "Alexander Bugge Stage",
+      "email": "abs@clerk.io"
+    },
     {
       "name": "Casper Kromann Nielsen",
       "email": "ckn@clerk.io"
+    },
+    {
+      "name": "Kim Kyhlensø",
+      "email": "kky@clerk.io"
     }
   ],
   "type": "magento2-module",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -34,6 +34,10 @@
                     <label>Language</label>
                     <source_model>Clerk\Clerk\Model\Config\Source\Language</source_model>
                 </field>
+                <field id="store_id" translate="label" type="select" sortOrder="70" showInDefault="0" showInWebsite="1" showInStore="1">
+                    <label>Store ID</label>
+                    <source_model>Clerk\Clerk\Model\Config\Source\Language</source_model>
+                </field>
             </group>
             <group id="product_synchronization" translate="label" type="text" sortOrder="20" showInDefault="0" showInWebsite="1" showInStore="1">
                 <label>Synchronization</label>
@@ -230,6 +234,10 @@
                         <field id="*/*/enabled">1</field>
                     </depends>
                 </field>
+                <field id="powerstep_filter" translate="label" type="select" sortOrder="40" showInDefault="0" showInWebsite="1" showInStore="1">
+                    <label>Filter Duplicates</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
             <group id="exit_intent" translate="label" type="text" sortOrder="60" showInDefault="0" showInWebsite="1" showInStore="1">
                 <label>Exit Intent</label>
@@ -256,6 +264,10 @@
                         <field id="*/*/enabled">1</field>
                     </depends>
                 </field>
+                <field id="category_filter" translate="label" type="select" sortOrder="40" showInDefault="0" showInWebsite="1" showInStore="1">
+                    <label>Filter Duplicates</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
             <group id="product" translate="label" type="text" sortOrder="80" showInDefault="0" showInWebsite="1" showInStore="1">
                 <label>Product Settings</label>
@@ -269,6 +281,10 @@
                         <field id="*/*/enabled">1</field>
                     </depends>
                 </field>
+                <field id="product_filter" translate="label" type="select" sortOrder="30" showInDefault="0" showInWebsite="1" showInStore="1">
+                    <label>Filter Duplicates</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
             <group id="cart" translate="label" type="text" sortOrder="90" showInDefault="0" showInWebsite="1" showInStore="1">
                 <label>Cart Settings</label>
@@ -281,6 +297,10 @@
                     <depends>
                         <field id="*/*/enabled">1</field>
                     </depends>
+                </field>
+                <field id="cart_filter" translate="label" type="select" sortOrder="30" showInDefault="0" showInWebsite="1" showInStore="1">
+                    <label>Filter Duplicates</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
             </group>
             <group id="log" translate="label" type="text" sortOrder="95" showInDefault="0" showInWebsite="1" showInStore="1">

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Clerk_Clerk" setup_version="4.5.1">
+    <module name="Clerk_Clerk" setup_version="4.6.0">
         <sequence>
             <module name="Magento_CatalogSearch"/>
         </sequence>

--- a/view/adminhtml/templates/facettitles.phtml
+++ b/view/adminhtml/templates/facettitles.phtml
@@ -2,7 +2,7 @@
 /** @var \Clerk\Clerk\Block\Adminhtml\System\Config\Field\FacetTitles $block */
 $element = $block->getElement();
 $values = [];
-$values = json_decode($element->getValue(), true);
+$values = is_null($element->getValue()) ? array() : json_decode($element->getValue(), true);
 ?>
 <div class="admin__control-table-wrapper">
     <table class="admin__control-table" id="attribute-labels-table">

--- a/view/frontend/templates/added.phtml
+++ b/view/frontend/templates/added.phtml
@@ -20,36 +20,42 @@
     </div>
 </div>
 <div class="powerstep-templates">
-    <?php
-    $Issetdataexclude = false;
-    $dataexcludestring = '';
-    $count = 0;
-    foreach ($block->getTemplates() as $template) :
-        $count++;
-        $id = 'clerk_'.$block->generateRandomString();
-        ?>
-        <span class="clerk"
-              id="<?php echo $id ?>"
-              <?php if($Issetdataexclude) {
-                  echo 'data-exclude-from="'.$dataexcludestring.'"';
-              } ?>
-              data-template="@<?php echo str_replace(' ','',$template); ?>"
-              data-products="[<?php echo $block->getProduct()->getId(); ?>]"
-              data-category="<?php echo $block->getProduct()->getCategoryId(); ?>"
-        ></span>
+<?php
+    $filter_duplicates = $block->getExcludeState();
+    $slider_count = 0;
+    $spanAttributes = [];
+    $spanAttributes['class'] = 'clerk';
+    $spanAttributes['products'] = $block->getProduct()->getId();
+    $spanAttributes['category'] = $block->getProduct()->getCategoryId();
 
-
-        <?php
-
-        if ($count == 1) {
-
-            $dataexcludestring .= '#'.$id.':limit(4)';
-
-        }else {
-
-            $dataexcludestring .= ',#'.$id.':limit(4)';
-
+    foreach ($block->getTemplates() as $template):
+        if($filter_duplicates){
+            $spanAttributes['class'] = 'clerk clerk_' . (string)$slider_count;
         }
-        $Issetdataexclude = true;
-    endforeach; ?>
+        if($slider_count > 0 && $filter_duplicates){
+            $filter_string = '';
+            for($i = 0; $i < $slider_count; $i++){
+                if($i > 0){
+                    $filter_string .= ', ';
+                }
+                $filter_string .= '.clerk_'.(string)$i;
+            }
+            $spanAttributes['exclude'] = $filter_string;
+        }
+    ?>
+    <span
+        class="<?php echo $spanAttributes['class']; ?>"
+        <?php
+        if($slider_count > 0 && $filter_duplicates){
+            echo 'data-exclude-from="'.$spanAttributes['exclude'].'"';
+        }
+        ?>
+        data-template="@<?php echo str_replace(' ','',$template); ?>"
+        data-products="[<?php echo $spanAttributes['products']; ?>]"
+        data-category="<?php echo $spanAttributes['category']; ?>"
+    ></span>
+    <?php
+    $slider_count++;
+    endforeach;
+    ?>
 </div>

--- a/view/frontend/templates/powerstep_popup.phtml
+++ b/view/frontend/templates/powerstep_popup.phtml
@@ -16,38 +16,43 @@ $categoryIds = $block->getProduct() ? $block->getProduct()->getCategoryIds() : [
     </div>
     <div class="clerk_powerstep_templates">
     <?php
-    $Issetdataexclude = false;
-    $dataexcludestring = '';
-    $count = 0;
-    foreach ($block->getTemplates() as $template) :
-        $count++;
-        $id = 'clerk_'.$block->generateRandomString();
-    ?>
-        <span class="clerk"
-              id="<?php echo $id ?>"
-              <?php if($Issetdataexclude) {
+    $filter_duplicates = $block->getExcludeState();
+    $slider_count = 0;
+    $spanAttributes = [];
+    $spanAttributes['class'] = 'clerk';
+    $spanAttributes['products'] = $block->escapeHtmlAttr($block->getProduct()->getId());
+    $spanAttributes['category'] = $block->escapeHtmlAttr(reset($categoryIds));
 
-                  echo 'data-exclude-from="'.$dataexcludestring.'"';
-
-              } ?>
-              data-template="@<?php echo $block->escapeHtmlAttr($template); ?>"
-              data-products="[<?php echo $block->escapeHtmlAttr($block->getProduct()->getId()); ?>]"
-              data-category="<?php echo $block->escapeHtmlAttr(reset($categoryIds)); ?>"
-        ></span>
-    <?php
-
-        if ($count == 1) {
-
-            $dataexcludestring .= '#'.$id.':limit(4)';
-
-        }else {
-
-            $dataexcludestring .= ',#'.$id.':limit(4)';
-
+    foreach ($block->getTemplates() as $template):
+        if($filter_duplicates){
+            $spanAttributes['class'] = 'clerk clerk_' . (string)$slider_count;
         }
-        $Issetdataexclude = true;
-
-    endforeach; ?>
+        if($slider_count > 0 && $filter_duplicates){
+            $filter_string = '';
+            for($i = 0; $i < $slider_count; $i++){
+                if($i > 0){
+                    $filter_string .= ', ';
+                }
+                $filter_string .= '.clerk_'.(string)$i;
+            }
+            $spanAttributes['exclude'] = $filter_string;
+        }
+    ?>
+    <span
+        class="<?php echo $spanAttributes['class']; ?>"
+        <?php
+        if($slider_count > 0 && $filter_duplicates){
+            echo 'data-exclude-from="'.$spanAttributes['exclude'].'"';
+        }
+        ?>
+        data-template="@<?php echo $block->escapeHtmlAttr($template); ?>"
+        data-products="[<?php echo $spanAttributes['products']; ?>]"
+        data-category="<?php echo $spanAttributes['category']; ?>"
+    ></span>
+    <?php
+    $slider_count++;
+    endforeach;
+    ?>
     </div>
 </div>
 <script>

--- a/view/frontend/templates/tracking.phtml
+++ b/view/frontend/templates/tracking.phtml
@@ -13,9 +13,12 @@
         Clerk('config', {
             key: '<?php echo $block->escapeJsQuote($block->getPublicKey()); ?>',
             collect_email: <?php echo $block->getCollectionEmails(); ?>,
-            <?php if (strpos($block->getLanguage(), 'auto_') === false && $block->getLanguage() != "") {
+            <?php
+            $current_language = is_null($block->getLanguage()) ? 'False' : $block->getLanguage();
+            if (strpos($current_language, 'auto_') === false && $block->getLanguage() != "") {
                 echo "language: '".$block->escapeJsQuote($block->getLanguage())."',";
-            }?>
+            }
+            ?>
             globals: {
                 uenc: '<?php echo base64_encode((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]"); ?>',
                 formkey: '<?php echo $block->getFormKey(); ?>'
@@ -23,15 +26,15 @@
         });
 
           var collectbaskets = <?php echo $block->getCollectionBaskets(); ?>;
-          
+
           if(collectbaskets){
 
-            let open = XMLHttpRequest.prototype.open; 
+            let open = XMLHttpRequest.prototype.open;
             XMLHttpRequest.prototype.open = function() {
                 this.addEventListener("load", function(){
 
                     if( this.responseURL.includes("=cart")){
-                        
+
                         if (this.readyState === 4 && this.status === 200) {
                             var response = JSON.parse(this.responseText);
 
@@ -47,7 +50,7 @@
                             var clerk_last_productids = [];
                             if( localStorage.getItem('clerk_productids') !== null ){
                                 clerk_last_productids = localStorage.getItem('clerk_productids').split(",");
-                                clerk_last_productids = clerk_last_productids.map(Number);  
+                                clerk_last_productids = clerk_last_productids.map(Number);
                             }
                             clerk_productids = clerk_productids.sort((a, b) => a - b);
                             clerk_last_productids = clerk_last_productids.sort((a, b) => a - b);
@@ -61,13 +64,13 @@
                                 }
                             }
                             localStorage.setItem("clerk_productids", clerk_productids);
-                        }                         
+                        }
                     }
                 }, false);
                 open.apply(this, arguments);
             };
 
-        } 
+        }
 
 </script>
 <!-- End of Clerk.io E-commerce Personalisation tool - www.clerk.io -->


### PR DESCRIPTION
- Updated Pagination for Endpoints to have explicit offset.
- Added data exclude menu option for recommendations.
- Changed powerstep showstate to always reset after render without closing.
- Extended stock and price attributes to better handle grouped and bundle products.
- Updated module for PHP 8.1 and Mage 2.4.4
- Added fallback for invalid keys when calculating facets.
- Removed object manager from attribute construction.