### PR TITLE
Fixed composer name clerkio/magento2 to clerk/magento2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "clerkio/magento2",
+  "name": "clerk/magento2",
   "description": "",
   "version": "4.7.1",
   "authors": [


### PR DESCRIPTION
When we try to install the module by using the composer name clerkio/magento2 then it gives error like:

_[InvalidArgumentException]                                                                                                                                                                                          
  Could not find a matching version of package clerkio/magento2. Check the package spelling, your version constraint and that the package is available in a stability which matches your minimum-stability (stable)_
  
### **Reason:**
 In the packagist,  the module has been released with the clerk/magento2 name and the composer name is not aligned with it. That's why it gives the error as above.