### PR TITLE
Fix store selector in widget (multistore)

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -351,6 +351,14 @@ class Api
                 'limit',
                 'category'
             ],
+            'recommendations/category/new' => [
+                'limit',
+                'category'
+            ],
+            'recommendations/category/complementary' => [
+                'limit',
+                'category'
+            ],
             'recommendations/visitor/history' => [
                 'limit',
             ],

--- a/view/adminhtml/templates/widget.phtml
+++ b/view/adminhtml/templates/widget.phtml
@@ -7,13 +7,13 @@
         });
 
         $(document).on('change', 'select#clerk_widget_content', function() {
-            getParametersForContent($(this).val());
+            getParametersForContent($(this).val(), $("#<?php echo $block->getSelectId(); ?>").val());
         });
 
         function getContentForStore(storeId) {
             $.ajax({
                 url: "<?php echo $block->getAjaxUrl(); ?>",
-                data: { type: 'content', store_id : storeId },
+                data: { type: 'content', store : storeId },
                 dataType: 'json',
                 showLoader: true,
                 success: function(response) {
@@ -24,10 +24,10 @@
             });
         }
 
-        function getParametersForContent(content) {
+        function getParametersForContent(content, storeId) {
             $.ajax({
                 url: "<?php echo $block->getAjaxUrl(); ?>",
-                data: { type: 'parameters', content : content },
+                data: { type: 'parameters', content : content, store : storeId },
                 dataType: 'json',
                 showLoader: true,
                 success: function(response) {


### PR DESCRIPTION
Store id was sent with the wrong var in the first function and missing in the second.

To reproduce:

1. Insert widget
2. Select widget type: Clerk content
3. Select a store

Output: No content found
Expected output: List of content available

Without the proper store id variable, the API requests fail since the matching API key is missing.
This probably only happens on a multistore, since the code tries to fallback on the default config API key. For our setup the default config for Clerk is empty, but only set on store level.

While testing saw there were 2 missing endpoint parameters. Maybe more, just noticed these onces since we have content for them.