### PR TITLE
Fixes using Exception from global namespace.

### DIFF
--- a/Model/Adapter/Product.php
+++ b/Model/Adapter/Product.php
@@ -846,7 +846,7 @@ class Product extends AbstractAdapter
                 }
             }
         }
-    } catch (Exception $e) {
+    } catch (\Exception $e) {
     }
     return $stockQuantity;
   }


### PR DESCRIPTION
Another small problem phpstan detected on level 0:
```
 ------ ---------------------------------------------------------------------------------------------------------------------
  Line   Model/Adapter/Product.php
 ------ ---------------------------------------------------------------------------------------------------------------------
  849    Caught class Clerk\Clerk\Model\Adapter\Exception not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
 ------ ---------------------------------------------------------------------------------------------------------------------
```

Has been fixed here 🙂 