### PR TITLE
Fixed 2 crashes that can happen in the powerstep popup when no sessio…

### DIFF
--- a/Block/PowerstepPopup.php
+++ b/Block/PowerstepPopup.php
@@ -112,11 +112,13 @@ class PowerstepPopup extends Template
      */
     public function getImageUrl()
     {
-        $product = $this->getProduct();
+        if ($product = $this->getProduct()) {
+            return $this->imageHelper->init($product, 'product_page_image_small')
+                ->setImageFile($product->getImage())
+                ->getUrl();
+        }
 
-        return $this->imageHelper->init($product, 'product_page_image_small')
-            ->setImageFile($product->getImage())
-            ->getUrl();
+        return '';
     }
 
     /**

--- a/view/frontend/templates/powerstep_popup.phtml
+++ b/view/frontend/templates/powerstep_popup.phtml
@@ -1,6 +1,7 @@
 <?php
 /** @var \Clerk\Clerk\Block\PowerstepPopup $block */
 $categoryIds = $block->getProduct() ? $block->getProduct()->getCategoryIds() : [];
+$productId = $block->getProduct() ? $block->getProduct()->getId() : '';
 ?>
 <?php if ($block->shouldShow()): ?>
 <div id="clerk_powerstep" class="clerk-popup">
@@ -20,7 +21,7 @@ $categoryIds = $block->getProduct() ? $block->getProduct()->getCategoryIds() : [
     $slider_count = 0;
     $spanAttributes = [];
     $spanAttributes['class'] = 'clerk';
-    $spanAttributes['products'] = $block->escapeHtmlAttr($block->getProduct()->getId());
+    $spanAttributes['products'] = $block->escapeHtmlAttr($productId);
     $spanAttributes['category'] = $block->escapeHtmlAttr(reset($categoryIds));
 
     foreach ($block->getTemplates() as $template):


### PR DESCRIPTION
…n exists.

Found this error in a log file on the server:
```
[2024-01-30T12:47:55.070761+00:00] main.CRITICAL: Error: Call to a member function getImage() on bool in vendor/clerk/magento2/Block/PowerstepPopup.php:118
```

After fixing that problem, I ran into the next problem:
```
Error: Call to a member function getId() on bool in vendor/clerk/magento2/view/frontend/templates/powerstep_popup.phtml:23
```

This PR fixes both problems. Not sure if you would consider this the best way to handle it though.


Is not super important, but it appears this happens when you have no session and visit an url like https://www.example.com/clerk/powerstep/popup?isAjax=true (easiest way to simulate having no session, is using an incognito window in your browser and directly visiting this url without visiting anything else)