### PR TITLE
Fix "image_type" being ignored

### DIFF
--- a/Helper/Image.php
+++ b/Helper/Image.php
@@ -76,7 +76,7 @@ class Image
             }
         }
 
-        if (!$imageUrl || $scopeId) {
+        if (!$imageUrl) {
             if ($scopeId) {
                 $store = $this->storeManager->getStore($scopeId);
             } else {


### PR DESCRIPTION
Hiya, while syncing data to Clerk we noticed our `image_type` setting is being ignored.

The image with correct `image_type` is succesfully retrieved at:
https://github.com/clerkio/clerk-magento2/blob/master/Helper/Image.php#L72

But later overwritten when `$scopeId` is set at:
https://github.com/clerkio/clerk-magento2/blob/master/Helper/Image.php#L79

Not sure what the purpose of the `$scopeId` check is in that line, looks to me it can safely be removed.