### PR TITLE
Fixes some code which is considered deprecated as of PHP 8.5

### DIFF
--- a/Controller/Logger/ClerkLogger.php
+++ b/Controller/Logger/ClerkLogger.php
@@ -367,7 +367,9 @@ class ClerkLogger
 
                     }
 
-                    curl_close($curl);
+                    if (PHP_VERSION_ID < 80000) {
+                        curl_close($curl);
+                    }
 
                 } elseif ($this->Log_to == 'file') {
 
@@ -442,7 +444,9 @@ class ClerkLogger
 
                 }
 
-                curl_close($curl);
+                if (PHP_VERSION_ID < 80000) {
+                    curl_close($curl);
+                }
 
             } elseif ($this->Log_to == 'file') {
 
@@ -521,7 +525,9 @@ class ClerkLogger
 
                     }
 
-                    curl_close($curl);
+                    if (PHP_VERSION_ID < 80000) {
+                        curl_close($curl);
+                    }
 
                 } elseif ($this->Log_to == 'file') {
 

--- a/Model/Adapter/Product.php
+++ b/Model/Adapter/Product.php
@@ -717,7 +717,7 @@ class Product extends AbstractAdapter
                     foreach ($productsArray as $bundle_item) {
                         $bundle_option_min_stock = 0;
                         foreach ($bundle_item as $bundle_option) {
-                            if ((integer)$bundle_option['min_qty'] <= $bundle_option['stock']) {
+                            if ((int)$bundle_option['min_qty'] <= $bundle_option['stock']) {
                                 $bundle_option_min_stock = ($bundle_option_min_stock == 0) ? $bundle_option['stock'] : $bundle_option_min_stock;
                                 $bundle_option_min_stock = ($bundle_option_min_stock < $bundle_option['stock']) ? $bundle_option['stock'] : $bundle_option_min_stock;
                             }
@@ -768,7 +768,7 @@ class Product extends AbstractAdapter
                     foreach ($productsArray as $bundle_item) {
                         $bundle_option_min_stock = 0;
                         foreach ($bundle_item as $bundle_option) {
-                            if ((integer)$bundle_option['min_qty'] <= $bundle_option['stock']) {
+                            if ((int)$bundle_option['min_qty'] <= $bundle_option['stock']) {
                                 $bundle_option_min_stock = ($bundle_option_min_stock == 0) ? $bundle_option['stock'] : $bundle_option_min_stock;
                                 $bundle_option_min_stock = ($bundle_option_min_stock < $bundle_option['stock']) ? $bundle_option['stock'] : $bundle_option_min_stock;
                             }

--- a/Model/Api.php
+++ b/Model/Api.php
@@ -180,7 +180,11 @@ class Api
             $curl = curl_init($url);
             curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
             $response = curl_exec($curl);
-            curl_close($curl);
+
+            if (PHP_VERSION_ID < 80000) {
+                curl_close($curl);
+            }
+
             return $response;
 
         } catch (\Exception $e) {
@@ -201,7 +205,11 @@ class Api
             }
             curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
             $response = curl_exec($curl);
-            curl_close($curl);
+
+            if (PHP_VERSION_ID < 80000) {
+                curl_close($curl);
+            }
+
             return $response;
 
         } catch (\Exception $e) {


### PR DESCRIPTION
PHP 8.5 got released yesterday: https://www.php.net/archive/2025.php#2025-11-20-3, and yes I know, Magento doesn't support it yet, but we can already prepare for the future a bit here.

Running [php compatibility checker](https://github.com/PHPCompatibility/PHPCompatibility/) on the codebase here results in this output:
```
FILE: vendor/clerk/magento2/Controller/Logger/ClerkLogger.php
----------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 3 WARNINGS AFFECTING 3 LINES
----------------------------------------------------------------------------------------------------------------------------------------
 370 | WARNING | Function curl_close() is deprecated since PHP 8.5 (PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated)
 445 | WARNING | Function curl_close() is deprecated since PHP 8.5 (PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated)
 524 | WARNING | Function curl_close() is deprecated since PHP 8.5 (PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated)
----------------------------------------------------------------------------------------------------------------------------------------


FILE: vendor/clerk/magento2/Model/Adapter/Product.php
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AND 2 WARNINGS AFFECTING 3 LINES
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 720 | WARNING | The integer cast is deprecated since PHP 8.5; Use (int) instead (PHPCompatibility.TypeCasts.RemovedTypeCasts.integerDeprecated)
 771 | WARNING | The integer cast is deprecated since PHP 8.5; Use (int) instead (PHPCompatibility.TypeCasts.RemovedTypeCasts.integerDeprecated)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


FILE: vendor/clerk/magento2/Model/Api.php
----------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
----------------------------------------------------------------------------------------------------------------------------------------
 183 | WARNING | Function curl_close() is deprecated since PHP 8.5 (PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated)
 204 | WARNING | Function curl_close() is deprecated since PHP 8.5 (PHPCompatibility.FunctionUse.RemovedFunctions.curl_closeDeprecated)
----------------------------------------------------------------------------------------------------------------------------------------
```

See:
- https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.core.non-canonical-cast-names
- https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.curl
- https://www.php.net/manual/en/function.curl-close.php


This PR fixes all these. For the `curl_close` method, I choose to wrap them in checks to see which PHP version is executed at runtime, according to the docs (see above), this function call only worked on PHP versions lower then 8.0