### PR TITLE
Fix: Clear type instance cache to prevent child product data corruption

### DIFF
--- a/Model/Adapter/AbstractAdapter.php
+++ b/Model/Adapter/AbstractAdapter.php
@@ -155,6 +155,12 @@ abstract class AbstractAdapter
       $heavyAttributeQuery = $this->scopeConfig->getValue(Config::XML_PATH_PRODUCT_SYNCHRONIZATION_ADDITIONAL_FIELDS_HEAVY_QUERY, $scope, $scopeid);
       $customFields = is_string($additionalFields) ? str_replace(' ', '', explode(',', $additionalFields)) : [];
       $resourceItemTypeId = $resourceItem->getTypeId();
+      
+      // Fix: Reset type instance to clear cached child product data
+      // Magento's type instance caches getUsedProducts() and getAssociatedProducts() results
+      // which causes child data (IDs, images, prices) to be shared between different products
+      // when the same adapter instance processes multiple products sequentially (e.g., in observers)
+      $resourceItem->setTypeInstance(null);
       $resourceItemTypeInstance = $resourceItem->getTypeInstance();
 
       $this->setFields($customFields, $scope, $scopeid);


### PR DESCRIPTION
Problem:
When products are saved via the ProductSaveAfterObserver, the same ProductAdapter instance is reused across multiple sequential product saves. Magento's type instance caches the results of getUsedProducts() and getAssociatedProducts(), causing child product data (IDs, images, prices, stocks) from one configurable/grouped product to be incorrectly assigned to other products processed in the same session.

This bug only manifests during realtime updates (product saves throughout the day), not during full syncs via the /clerk/product endpoint, because:
- Realtime: Same adapter instance processes multiple products sequentially with cached data
- Full sync: Fresh products loaded per page, adapter released after each HTTP request

Impact:
- Affects all configurable and grouped products
- Corrupts child_ids, child_images, child_prices, child_list_prices, child_stocks
- Severity: HIGH - incorrect product data indexed and shown to customers
- Fixed by nightly full sync, but corrupted data persists during business hours

Solution:
Reset the type instance before processing each product to clear Magento's internal cache. This ensures each product gets its own fresh child product data.

The fix is minimal (2 lines), centralized in one location, and prevents the issue for all code paths without performance impact.

Changes:
- Model/Adapter/AbstractAdapter.php: Added setTypeInstance(null) call to clear cache

Testing:
Verified that sequential product saves now maintain correct child data without sharing cached type instance information between different products.