### PR TITLE
Added content header to API call

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -196,12 +196,28 @@ class Api
 
             $curl = curl_init($url);
             curl_setopt($curl, CURLOPT_POST, true);
+            curl_setopt($curl, CURLOPT_HTTPHEADER, [
+                'Content-Type: application/json',
+            ]);
             if (!empty($params)) {
                 curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($params, true));
             }
             curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
             $response = curl_exec($curl);
             curl_close($curl);
+
+            $decoded = json_decode($response, true);
+
+            if (is_array($decoded)) {
+                if (isset($decoded['status']) && $decoded['status'] === 'error') {
+                    $message = !empty($decoded['message'])
+                        ? $decoded['message']
+                        : 'Unknown Clerk API error.';
+
+                    throw new \Exception($message);
+                }
+            }
+
             return $response;
 
         } catch (\Exception $e) {


### PR DESCRIPTION
Added proper JSON handling and stricter error handling for Clerk API POST requests.

This change updates the API client to send POST payloads as JSON with the correct Content-Type: application/json. Previously, Clerk could not parse the request body correctly, which caused errors like The required argument "key" is missing even when the parameter was present in the payload.

The error handling has also been improved. Non-success Clerk API responses are now detected explicitly. When Clerk returns a response with status: "error", the client now throws an exception using the message returned by the API, instead of failing silently. This makes integration issues easier to debug and prevents invalid responses from being treated as successful requests.